### PR TITLE
Don't overwrite the cargo pod created event if one already exists

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,4 +1,5 @@
 require("util")
+local meld = require("meld")
 
 for _, lab in pairs(data.raw.lab) do
     if not contains(lab.inputs, "bioluminescent-science-pack") then
@@ -6,7 +7,7 @@ for _, lab in pairs(data.raw.lab) do
     end
 end
 
-data.raw["cargo-pod"]["cargo-pod"].created_effect = {
+meld.meld({
     {
         type = "direct",
         action_delivery = {
@@ -14,7 +15,7 @@ data.raw["cargo-pod"]["cargo-pod"].created_effect = {
             delayed_trigger = "cargo-pod-malfunction"
         }
     }
-}
+}, data.raw["cargo-pod"]["cargo-pod"].created_effect)
 
 data:extend({
     {


### PR DESCRIPTION
fixes nicholasgower/tenebris-prime#12

Tested both with the known conflicting mod and without, so should be safe (i.e. meld handles possible undefined target perfectly fine).

If there's a stronger conflict where both mods edit the exact same property like a string then your mod still takes precedence, I didn't bother trying to handle that.