### PR TITLE
Improve compatibility with modded labs and endgame techs

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,11 +1,5 @@
 require("util")
 
-for _, lab in pairs(data.raw.lab) do
-    if not contains(lab.inputs, "bioluminescent-science-pack") then
-        table.insert(lab.inputs, "bioluminescent-science-pack")
-    end
-end
-
 data.raw["cargo-pod"]["cargo-pod"].created_effect = {
     {
         type = "direct",

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,2 +1,6 @@
 require("__tenebris-prime__.prototypes.bioluminescent")
 require("__tenebris-prime__.compat.maraxsis")
+
+if data.raw.lab["lab"] then
+  table.insert(data.raw.lab["lab"].inputs, "bioluminescent-science-pack")
+end


### PR DESCRIPTION
Some mods add specialised labs not intended to hold every science pack. By forcibly adding the science pack to every lab in `data-final-fixes.lua`, it only becomes a matter of load order determining whether or not a given lab would mistakenly include it. In addition, some techs, like Frozeta's Science pack productivity, want to have every science pack available to the default lab, which may not have Tenebris's science pack if it was loaded later.

Only adding the default lab instead of also the biolab is fine due to the dependency on PlanetsLib, which mirrors all default lab sciences into the biolab in `data-final-fixes.lua`. It also has an option for mods to mark their own labs to mirror the default lab sciences as well (or they might do so manually), meaning that Tenebris doesn't have to worry about that either.