### PR TITLE
Update bioluminescent.lua

### DIFF
--- a/prototypes/bioluminescent.lua
+++ b/prototypes/bioluminescent.lua
@@ -72,6 +72,11 @@ local function create_bioluminescent_entity(entities, cost, entity_mod, exclude,
 
             if not item then goto skip end
 
+			local bioluminescent_next_upgrade = nil
+			if entity.next_upgrade then 
+				bioluminescent_next_upgrade = "bioluminescent-" .. entity.next_upgrade
+			end
+
             local name = "bioluminescent-" .. entity.name
             result[name] =
                 meld(table.deepcopy(entity), {
@@ -92,7 +97,8 @@ local function create_bioluminescent_entity(entities, cost, entity_mod, exclude,
                             property = "pressure",
                             min = 3000,
                             max = 3000
-                        }
+                        },
+					    next_upgrade = bioluminescent_next_upgrade
                     }
                 })
 


### PR DESCRIPTION
maybe fix for https://github.com/nicholasgower/tenebris-prime/issues/5

seems to work for me with quite some mods active (i.e. doesn't crash)... tried only that it works for a few belts.

not the cleanest code since e.g. there should probably be checks whether `"bioluminescent-" .. entity.next_upgrade` really exists, though I suppose it would have to by looking at the way the mod chooses for which entities to add `bioluminescent` entities (https://github.com/nicholasgower/tenebris-prime/blob/da789e6653917ae037a50629060c0863b2349c16/prototypes/bioluminescent.lua#L200C49-L200C75 - they just create additonal entities for the whole prototype type, e.g. `transport-belt` (https://wiki.factorio.com/Data.raw#transport-belt)). I don't think Factorio or mods define entities having `next_upgrade` which are of a different prototype type, but I'm not sure.

Finally, that's what's been suggested here by another mod author: https://mods.factorio.com/mod/tenebris/discussion/6754a0be6a830b97322340b6, so I don't feel too bad about this approach...

well - works for me so far, so I thought I'd share...