### PR TITLE
Canal Excavator Compatibility

### DIFF
--- a/compat/canal-excavator-data-final-fixes.lua
+++ b/compat/canal-excavator-data-final-fixes.lua
@@ -1,0 +1,13 @@
+if not mods["canal-excavator"] then return end
+
+local excavator = data.raw["mining-drill"]["bioluminescent-canex-excavator"]
+local index
+for i, category in pairs(excavator.resource_categories) do
+  if category == "canex-rsc-cat-digable" then
+    index = i
+    break
+  end
+end
+if index then
+  table.remove(excavator.resource_categories, index)
+end

--- a/compat/canal-excavator-data.lua
+++ b/compat/canal-excavator-data.lua
@@ -1,0 +1,30 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-tenebris-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "tenebris",
+    localisation = {"space-location-name.tenebris"},
+    oreStartingAmount = 10,
+    mining_time = 4,
+    tint = {r = 28, g = 223, b = 247},
+    mineResult = {
+      {type="item", name = "spoilage", probability = 0.95, amount = 1},
+      {type="item", name = "luciferin", probability = 0.05, amount = 1},
+      {type="item", name = "chitin", probability = 0.01, amount = 1},
+      {type="item", name = "pentapod-egg", probability = 0.01, amount = 1},
+    },
+    custom_resource_category = "canex-rsc-cat-tenebris"
+  },
+}, {
+  type = "mod-data",
+  name = "canex-excavator-tenebris",
+  data_type = "canex-excavator-config",
+  data = {
+    entity_name = "bioluminescent-canex-excavator",
+    item_name = "bioluminescent-canex-excavator",
+    custom_resource_category = "canex-rsc-cat-tenebris"
+  }
+}})

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -42,3 +42,5 @@ for _, tech in pairs(science_to_update) do
 end
 
 table.insert(data.raw["item"]["foundation"].place_as_tile.tile_condition, "sulfuric-acid-tile"); --From ams-acid-landfill
+
+require("__tenebris-prime__.compat.canal-excavator-data-final-fixes")

--- a/data.lua
+++ b/data.lua
@@ -18,3 +18,5 @@ require("__tenebris-prime__.prototypes.entity.decorative")
 
 
 require("__tenebris-prime__.prototypes.bioluminescent")
+
+require("__tenebris-prime__.compat.canal-excavator-data")

--- a/info.json
+++ b/info.json
@@ -14,6 +14,7 @@
     "! ams-acid-landfill",
     "! beacon_maraxsis_tenebris",
     "! tenebris_sulfur",
-    "! tenebris"
+    "! tenebris",
+    "? canal-excavator >= 1.12"
   ]
 }


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so let me know if you're okay with adding this.

If you want you could change the dependency to hidden `(?)`, but I leave that up to you.

Since Tenebris seems to be teeming with life, I've chose to yield a combination of resources when the ground is excavated which you can find in the `canex-tenebris-config` structure. But you can modify it if you don't like that idea. 

Furthermore, since your mod introduces a bioluminescent copy of the excavator, I've created a custom resource category for that excavator and remove the standard category from the prototype.

Let me know what you think.
Cheers!